### PR TITLE
Fix evaluation with unordered keyword arguments

### DIFF
--- a/Wff.py
+++ b/Wff.py
@@ -156,7 +156,7 @@ class WFF(object):
         vals = {k: v for k, v in vals.items() if k in self.atoms}
 
         # If not all atoms are contained in given values, return a sub-truth_table
-        if [*vals] != self.atoms:
+        if set(vals.keys()) != set(self.atoms):
             return_list = []
             for row in self.truth_table:
                 if all([v == row[0][k] for k, v in vals.items()]):


### PR DESCRIPTION
## Summary
- ensure evaluation works regardless of keyword ordering

## Testing
- `python -m py_compile Lexer.py Logic.py Wff.py`


------
https://chatgpt.com/codex/tasks/task_e_684a13ba0010832092b3169abbe0470b