### PR TITLE
Add comprehensive tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is in the path for module imports
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,38 @@
+import pytest
+import Lexer
+import Logic
+
+
+def test_tokenize_simple():
+    tokens = Lexer.tokenize('a*b')
+    assert tokens == [('a', 'Predicate'), ('*', 'Conjunction'), ('b', 'Predicate')]
+
+
+def test_tokenize_unbalanced():
+    with pytest.raises(SyntaxError):
+        Lexer.tokenize('(a+b')
+
+
+def test_parse_conjunction():
+    ast, atoms = Lexer.parse('a*b')
+    assert atoms == ['a', 'b']
+    assert ast == (Logic.conjunction, ['a', 'b'])
+
+
+def test_parse_negation():
+    ast, atoms = Lexer.parse('~a')
+    assert atoms == ['a']
+    assert ast == (Logic.negation, ['a'])
+
+
+def test_parse_complex():
+    ast, atoms = Lexer.parse('(a+b)&~c')
+    expected = (
+        Logic.conjunction,
+        [
+            (Logic.disjunction, ['a', 'b']),
+            (Logic.negation, ['c'])
+        ]
+    )
+    assert atoms == ['a', 'b', 'c']
+    assert ast == expected

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,27 @@
+import Logic
+
+
+def test_negation():
+    assert Logic.negation(True) is False
+    assert Logic.negation(False) is True
+
+
+def test_conjunction():
+    assert Logic.conjunction(True, True)
+    assert not Logic.conjunction(True, False)
+
+
+def test_disjunction():
+    assert Logic.disjunction(False, True)
+    assert not Logic.disjunction(False, False)
+
+
+def test_implication():
+    assert Logic.implication(True, False) is False
+    assert Logic.implication(True, True) is True
+    assert Logic.implication(False, True) is True
+
+
+def test_biconditional():
+    assert Logic.biconditional(True, True) is True
+    assert Logic.biconditional(True, False) is False

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,0 +1,24 @@
+from Wff import simplify
+
+
+def test_simplify_equality():
+    assert simplify([{'a': True}, {'a': True}]) == [{'a': True}]
+
+
+def test_simplify_cancellation():
+    assert simplify([{'a': True}, {'a': False}]) == []
+
+
+def test_simplify_adjacency():
+    terms = [{'a': True, 'b': True, 'c': True}, {'a': True, 'b': False, 'c': True}]
+    assert simplify(terms) == [{'a': True, 'c': True}]
+
+
+def test_simplify_absorption():
+    terms = [{'a': True, 'b': True, 'c': True}, {'a': True, 'b': True}]
+    assert simplify(terms) == [{'a': True, 'b': True}]
+
+
+def test_simplify_reduction():
+    terms = [{'a': True, 'b': True}, {'a': True, 'b': False, 'c': True}]
+    assert simplify(terms) == [{'a': True, 'b': True}, {'a': True, 'c': True}]

--- a/tests/test_wff.py
+++ b/tests/test_wff.py
@@ -1,0 +1,43 @@
+import Wff
+
+
+def test_str_and_atoms():
+    w = Wff.WFF('a*b')
+    assert str(w) == 'a*b'
+    assert w.atoms == ['a', 'b']
+
+
+def test_call_boolean():
+    w = Wff.WFF('a*b')
+    assert w(a=True, b=True) is True
+    assert w(a=True, b=False) is False
+
+
+def test_call_partial_table():
+    w = Wff.WFF('a*b')
+    subset = w(a=True)
+    assert subset == [({'a': True, 'b': True}, True), ({'a': True, 'b': False}, False)]
+
+
+def test_truth_table_and_density():
+    w = Wff.WFF('a*b')
+    assert len(w.truth_table) == 4
+    assert w.density() == 0.25
+
+
+def test_tautology_and_contradiction():
+    assert Wff.WFF('a+~a').is_tautology()
+    assert Wff.WFF('a*~a').is_contradiction()
+
+
+def test_derivative_infer():
+    h1 = Wff.WFF('a>b')
+    h2 = Wff.WFF('a')
+    concl = Wff.WFF('b')
+    assert Wff.derivative([h1, h2]).infer(concl)
+
+
+def test_format_cnf_dnf():
+    w = Wff.WFF('(a+b)&(a+~b)+~b&c')
+    assert w.format('DNF') == '(a)+(~b*c)'
+    assert w.format('CNF') == '(a+~b)*(a+c)'


### PR DESCRIPTION
## Summary
- add pytest configuration to include project root on path
- test core logical functions
- test lexical analysis and parser output
- test WFF class behavior and derivative/inference
- test Boolean algebra simplification helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a17298f8c83209ed1039a3c8edca0