### PR TITLE
Improve parser robustness

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -8,6 +8,15 @@ def test_tokenize_simple():
     assert tokens == [('a', 'Predicate'), ('*', 'Conjunction'), ('b', 'Predicate')]
 
 
+def test_tokenize_multichar_predicate_and_function():
+    tokens = lexer.tokenize('foo*Bar(x,y)')
+    assert tokens == [
+        ('foo', 'Predicate'),
+        ('*', 'Conjunction'),
+        ('Bar(x,y)', 'Function'),
+    ]
+
+
 def test_tokenize_unbalanced():
     with pytest.raises(SyntaxError):
         lexer.tokenize('(a+b')
@@ -36,3 +45,13 @@ def test_parse_complex():
     )
     assert atoms == ['a', 'b', 'c']
     assert ast == expected
+
+
+def test_parse_unexpected_end():
+    with pytest.raises(SyntaxError):
+        lexer.parse('a*')
+
+
+def test_parse_extra_characters():
+    with pytest.raises(SyntaxError):
+        lexer.parse('(a*b)c')


### PR DESCRIPTION
## Summary
- make lexer token patterns extensible and support multi-char names
- add error handling for unexpected input
- expose leftover token errors during parsing
- test extended token and new error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b43a6c684832082a1e3782be38c3b