### PR TITLE
Optimize proof search with operator indices

### DIFF
--- a/wff/proof.py
+++ b/wff/proof.py
@@ -2,6 +2,7 @@
 """Utilities for deriving classical proofs between well formed formulas."""
 
 import typing
+from collections import defaultdict, deque
 from .core import WFF
 from . import logic as Logic
 
@@ -66,12 +67,16 @@ class Proof:
     progress can be made.
     """
 
-    def __init__(self, premises: typing.List[WFF], conclusion: WFF) -> None:
+    def __init__(self, premises: typing.List[WFF], conclusion: WFF, search_limit: int = 100) -> None:
         self.premises = [p if isinstance(p, WFF) else WFF(p) for p in premises]
         self.conclusion = conclusion if isinstance(conclusion, WFF) else WFF(conclusion)
         self.steps: typing.List[ProofStep] = []
         self._known: typing.Dict[str, int] = {}
-        self._queue: typing.List[ProofStep] = []
+        self._op_index: typing.DefaultDict[typing.Any, typing.List[int]] = defaultdict(list)
+        self._queue_high = deque()
+        self._queue_low = deque()
+        self.search_limit = search_limit
+        self._target_atoms = set(self.conclusion.atoms)
 
     def _add_step(self, wff: WFF, rule: str, refs: typing.List[int]) -> int:
         """Register a new proof line if it hasn't been seen before."""
@@ -82,7 +87,12 @@ class Proof:
             self.steps.append(step)
             idx = len(self.steps)
             self._known[key] = idx
-            self._queue.append(step)
+            op = step.formula.ast[0] if isinstance(step.formula.ast, tuple) else None
+            self._op_index[op].append(idx)
+            if self._target_atoms.intersection(step.formula.atoms):
+                self._queue_high.append(step)
+            else:
+                self._queue_low.append(step)
             return idx
         return self._known[key]
 
@@ -104,63 +114,99 @@ class Proof:
         """Apply inference rules that depend on two premises."""
 
         ast = step.formula.ast
-        for j, other in enumerate(self.steps, start=1):
-            if j == idx:
-                continue
-            oast = other.formula.ast
+        op = ast[0] if isinstance(ast, tuple) else None
 
-            # Modus Ponens
-            if is_op(ast, Logic.implication) and ast_equal(oast, ast[1][0]):
-                self._add_step(WFF(ast_to_str(ast[1][1])), "Modus Ponens", [idx, j])
-            if is_op(oast, Logic.implication) and ast_equal(ast, oast[1][0]):
-                self._add_step(WFF(ast_to_str(oast[1][1])), "Modus Ponens", [j, idx])
+        # Modus Ponens and Tollens depend on implications
+        if op == Logic.implication:
+            p, q = ast[1]
+            j = self._known.get(ast_to_str(p))
+            if j:
+                self._add_step(WFF(ast_to_str(q)), "Modus Ponens", [idx, j])
+            for j in list(self._op_index[Logic.negation]):
+                oast = self.steps[j - 1].formula.ast
+                if ast_equal(oast[1][0], q):
+                    self._add_step(WFF(ast_to_str(negate_ast(p))), "Modus Tollens", [idx, j])
 
-            # Modus Tollens
-            if is_op(ast, Logic.implication) and is_op(oast, Logic.negation) and ast_equal(oast[1][0], ast[1][1]):
-                self._add_step(WFF(ast_to_str(negate_ast(ast[1][0]))), "Modus Tollens", [idx, j])
-            if is_op(oast, Logic.implication) and is_op(ast, Logic.negation) and ast_equal(ast[1][0], oast[1][1]):
-                self._add_step(WFF(ast_to_str(negate_ast(oast[1][0]))), "Modus Tollens", [j, idx])
-
-            # Disjunctive Syllogism
-            if is_op(ast, Logic.disjunction) and is_op(oast, Logic.negation):
-                p, q = ast[1]
-                if ast_equal(oast[1][0], p):
-                    self._add_step(WFF(ast_to_str(q)), "Disjunctive Syllogism", [idx, j])
-                elif ast_equal(oast[1][0], q):
-                    self._add_step(WFF(ast_to_str(p)), "Disjunctive Syllogism", [idx, j])
-            if is_op(oast, Logic.disjunction) and is_op(ast, Logic.negation):
+        else:
+            for j in list(self._op_index[Logic.implication]):
+                if j == idx:
+                    continue
+                oast = self.steps[j - 1].formula.ast
                 p, q = oast[1]
-                if ast_equal(ast[1][0], p):
-                    self._add_step(WFF(ast_to_str(q)), "Disjunctive Syllogism", [j, idx])
-                elif ast_equal(ast[1][0], q):
-                    self._add_step(WFF(ast_to_str(p)), "Disjunctive Syllogism", [j, idx])
+                if ast_equal(ast, p):
+                    self._add_step(WFF(ast_to_str(q)), "Modus Ponens", [j, idx])
+                if op == Logic.negation and ast_equal(ast[1][0], q):
+                    self._add_step(WFF(ast_to_str(negate_ast(p))), "Modus Tollens", [j, idx])
 
-            # Conjunction Introduction
-            if not is_op(ast, Logic.conjunction) and not is_op(oast, Logic.conjunction):
-                conj = (Logic.conjunction, [ast, oast])
-                self._add_step(WFF(ast_to_str(conj)), "Conjunction Introduction", [idx, j])
+        # Disjunctive Syllogism
+        if op == Logic.disjunction:
+            p, q = ast[1]
+            j = self._known.get(ast_to_str(negate_ast(p)))
+            if j:
+                self._add_step(WFF(ast_to_str(q)), "Disjunctive Syllogism", [idx, j])
+            j = self._known.get(ast_to_str(negate_ast(q)))
+            if j:
+                self._add_step(WFF(ast_to_str(p)), "Disjunctive Syllogism", [idx, j])
+        elif op == Logic.negation:
+            p = ast[1][0]
+            for j in list(self._op_index[Logic.disjunction]):
+                oast = self.steps[j - 1].formula.ast
+                a, b = oast[1]
+                if ast_equal(p, a):
+                    self._add_step(WFF(ast_to_str(b)), "Disjunctive Syllogism", [j, idx])
+                elif ast_equal(p, b):
+                    self._add_step(WFF(ast_to_str(a)), "Disjunctive Syllogism", [j, idx])
 
-            # Disjunction Introduction
-            disj1 = (Logic.disjunction, [ast, oast])
-            disj2 = (Logic.disjunction, [oast, ast])
-            self._add_step(WFF(ast_to_str(disj1)), "Disjunction Introduction", [idx])
-            self._add_step(WFF(ast_to_str(disj2)), "Disjunction Introduction", [j])
+        # Conjunction Introduction
+        if op != Logic.conjunction:
+            for op2, indexes in list(self._op_index.items()):
+                if op2 == Logic.conjunction:
+                    continue
+                for j in list(indexes):
+                    if j == idx:
+                        continue
+                    oast = self.steps[j - 1].formula.ast
+                    conj = (Logic.conjunction, [ast, oast])
+                    self._add_step(WFF(ast_to_str(conj)), "Conjunction Introduction", [idx, j])
 
-            # Biconditional Introduction
-            if is_op(ast, Logic.implication) and is_op(oast, Logic.implication):
+        # Disjunction Introduction
+        for op2, indexes in list(self._op_index.items()):
+            for j in list(indexes):
+                if j == idx:
+                    continue
+                oast = self.steps[j - 1].formula.ast
+                disj1 = (Logic.disjunction, [ast, oast])
+                disj2 = (Logic.disjunction, [oast, ast])
+                self._add_step(WFF(ast_to_str(disj1)), "Disjunction Introduction", [idx])
+                self._add_step(WFF(ast_to_str(disj2)), "Disjunction Introduction", [j])
+
+        # Biconditional Introduction
+        if op == Logic.implication:
+            for j in list(self._op_index[Logic.implication]):
+                if j == idx:
+                    continue
+                oast = self.steps[j - 1].formula.ast
                 p1, q1 = ast[1]
                 p2, q2 = oast[1]
                 if ast_equal(p1, q2) and ast_equal(q1, p2):
                     bicond = (Logic.biconditional, [p1, q1])
                     self._add_step(WFF(ast_to_str(bicond)), "Biconditional Introduction", [idx, j])
 
-            # Conditional Introduction (heuristic)
-            if idx in other.refs:
-                impl = (Logic.implication, [ast, oast])
-                self._add_step(WFF(ast_to_str(impl)), "Conditional Introduction", [idx, j])
-            if j in step.refs:
-                impl = (Logic.implication, [oast, ast])
-                self._add_step(WFF(ast_to_str(impl)), "Conditional Introduction", [j, idx])
+
+        # Conditional Introduction (heuristic)
+        for op2, indexes in list(self._op_index.items()):
+            for j in list(indexes):
+                if j == idx:
+                    continue
+                other = self.steps[j - 1]
+                oast = other.formula.ast
+                if idx in other.refs:
+                    impl = (Logic.implication, [ast, oast])
+                    self._add_step(WFF(ast_to_str(impl)), "Conditional Introduction", [idx, j])
+                if j in step.refs:
+                    impl = (Logic.implication, [oast, ast])
+                    self._add_step(WFF(ast_to_str(impl)), "Conditional Introduction", [j, idx])
+
 
     def _apply_ternary(self, idx: int, step: ProofStep) -> None:
         """Apply rules that require three premises, such as disjunctive elimination."""
@@ -168,25 +214,31 @@ class Proof:
         ast = step.formula.ast
         if is_op(ast, Logic.disjunction):
             p, q = ast[1]
-            for j, first in enumerate(self.steps, start=1):
+            for j in list(self._op_index[Logic.implication]):
                 if j == idx:
                     continue
-                a1 = first.formula.ast
-                if is_op(a1, Logic.implication) and ast_equal(a1[1][0], p):
-                    for k, second in enumerate(self.steps, start=1):
+                a1 = self.steps[j - 1].formula.ast
+                if ast_equal(a1[1][0], p):
+                    for k in list(self._op_index[Logic.implication]):
                         if k in (idx, j):
                             continue
-                        a2 = second.formula.ast
-                        if is_op(a2, Logic.implication) and ast_equal(a2[1][0], q) and ast_equal(a1[1][1], a2[1][1]):
+                        a2 = self.steps[k - 1].formula.ast
+                        if ast_equal(a2[1][0], q) and ast_equal(a1[1][1], a2[1][1]):
                             self._add_step(WFF(ast_to_str(a1[1][1])), "Disjunctive Elimination", [idx, j, k])
                             return
 
     def _search(self) -> None:
-        idx = 0
-        limit = 100
-        while idx < len(self._queue) and len(self.steps) < limit:
-            step = self._queue[idx]
-            idx += 1
+        from_high = True
+        while (self._queue_high or self._queue_low) and len(self.steps) < self.search_limit:
+            if from_high and self._queue_high:
+                step = self._queue_high.popleft()
+            elif not from_high and self._queue_low:
+                step = self._queue_low.popleft()
+            elif self._queue_high:
+                step = self._queue_high.popleft()
+            else:
+                step = self._queue_low.popleft()
+            from_high = not from_high
             line = self._known[str(step.formula)]
             if ast_equal(step.formula.ast, self.conclusion.ast):
                 return
@@ -195,24 +247,26 @@ class Proof:
             self._apply_ternary(line, step)
             if str(self.conclusion) in self._known:
                 return
-
     def derive(self) -> typing.List[ProofStep]:
         self.steps = []
         self._known = {}
-        self._queue = []
+        self._queue_high = deque()
+        self._queue_low = deque()
 
         for prem in self.premises:
             self._add_step(prem, "Assumption", [])
 
         self._search()
         if str(self.conclusion) in self._known:
-            return self.steps
+            idx = self._known[str(self.conclusion)]
+            return self.steps[:idx]
 
         neg_concl = WFF(f"~({self.conclusion})")
         self._add_step(neg_concl, "Assumption", [])
         self._search()
         if str(self.conclusion) in self._known:
-            return self.steps
+            idx = self._known[str(self.conclusion)]
+            return self.steps[:idx]
 
         lines = {}
         for i, step in enumerate(self.steps, start=1):


### PR DESCRIPTION
## Summary
- index proof steps by operator
- prioritize queue items based on goal atoms and alternate between priorities
- trim proofs once the conclusion is found
- update search loop to use the new queues

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d64c0700c8320a9a05973edffe228